### PR TITLE
Added Messy Dataset Links

### DIFF
--- a/CMS_event_analysis.ipynb
+++ b/CMS_event_analysis.ipynb
@@ -62,7 +62,7 @@
         "    'Single Electron': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Electron_Run2011A.csv\",\n",
         "    'Single Muon': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Muon_Run2011A.csv\" \n",
         "    'Messy Double Electron': \"https://drive.google.com/uc?export=download&id=13onXkQVkzO2akLK5bAnvQdPfH4gY8-W_&confirm=t\",\n",
-        "    'Messy Double Muon': \"https://drive.google.com/uc?export=download&id=1uIIfjiR4CGJ6W83tZF0glzQegzE7ZyXm&confirm=t\",\n"
+        "    'Messy Double Muon': \"https://drive.google.com/uc?export=download&id=1uIIfjiR4CGJ6W83tZF0glzQegzE7ZyXm&confirm=t\",\n",
         "}\n",
         "\n",
         "#@markdown If you want to download a local copy of the datasets, you can find them [here](\"https://github.com/QuarkNet-HEP/data-camp\")"

--- a/CMS_event_analysis.ipynb
+++ b/CMS_event_analysis.ipynb
@@ -293,7 +293,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Last revised 7/13/2022"
+        "Last revised 5/9/2023"
       ],
       "metadata": {
         "id": "MhR-ZMHrEIdN"

--- a/CMS_event_analysis.ipynb
+++ b/CMS_event_analysis.ipynb
@@ -54,24 +54,23 @@
       "source": [
         "#@title Choose your decay mode from the list below. \n",
         "#@markdown ###Then click the play button for this cell.\n",
-        "decay_channel = 'Double Electron' #@param[\"Double Electron\", \"Double Muon\", \"Single Electron\", \"Single Muon\"]\n",
+        "decay_channel = 'Double Electron' #@param[\"Double Electron\", \"Double Muon\", \"Single Electron\", \"Single Muon\", \"Messy Double Electron\", \"Messy Double Muon\"]\n",
         "\n",
         "datasets = {\n",
         "    'Double Electron': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Double_Electron_Run2011A.csv\",\n",
         "    'Double Muon': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Double_Muon_Run2011A.csv\",\n",
         "    'Single Electron': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Electron_Run2011A.csv\",\n",
-        "    'Single Muon': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Muon_Run2011A.csv\" \n",
-        "    'Messy Double Electron': \"https://drive.google.com/uc?export=download&id=13onXkQVkzO2akLK5bAnvQdPfH4gY8-W_&confirm=t\",\n",
-        "    'Messy Double Muon': \"https://drive.google.com/uc?export=download&id=1uIIfjiR4CGJ6W83tZF0glzQegzE7ZyXm&confirm=t\",\n",
+        "    'Single Muon': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Muon_Run2011A.csv\",\n",
+        "    'Messy Double Electron' : \"https://drive.google.com/uc?export=download&id=13onXkQVkzO2akLK5bAnvQdPfH4gY8-W_&confirm=t\",\n",
+        "    'Messy Double Muon' : \"https://drive.google.com/uc?export=download&id=1uIIfjiR4CGJ6W83tZF0glzQegzE7ZyXm&confirm=t\", \n",
         "}\n",
         "\n",
-        "#@markdown If you want to download a local copy of the datasets, you can find them [here](\"https://github.com/QuarkNet-HEP/data-camp\")"
+        "#@markdown If you want to download a local copy of the datasets, you can find them [here](\"https://github.com/QuarkNet-HEP/data-camp/data\")"
       ],
       "metadata": {
-        "id": "rynDiq8IqqIO",
-        "cellView": "form"
+        "id": "rynDiq8IqqIO"
       },
-      "execution_count": 2,
+      "execution_count": 4,
       "outputs": []
     },
     {
@@ -122,7 +121,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
+      "execution_count": null,
       "metadata": {
         "id": "NDwuBE73WtrV"
       },
@@ -320,7 +319,6 @@
       "version": "3.9.7"
     },
     "colab": {
-      "name": "CMS Event Analysis - Revised 7/2022",
       "provenance": [],
       "include_colab_link": true
     }

--- a/CMS_event_analysis.ipynb
+++ b/CMS_event_analysis.ipynb
@@ -61,6 +61,8 @@
         "    'Double Muon': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Double_Muon_Run2011A.csv\",\n",
         "    'Single Electron': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Electron_Run2011A.csv\",\n",
         "    'Single Muon': \"https://github.com/QuarkNet-HEP/data-camp/raw/main/data/Single_Muon_Run2011A.csv\" \n",
+        "    'Messy Double Electron': \"https://drive.google.com/uc?export=download&id=13onXkQVkzO2akLK5bAnvQdPfH4gY8-W_&confirm=t\",\n",
+        "    'Messy Double Muon': \"https://drive.google.com/uc?export=download&id=1uIIfjiR4CGJ6W83tZF0glzQegzE7ZyXm&confirm=t\",\n"
         "}\n",
         "\n",
         "#@markdown If you want to download a local copy of the datasets, you can find them [here](\"https://github.com/QuarkNet-HEP/data-camp\")"

--- a/data/read_me.md
+++ b/data/read_me.md
@@ -1,1 +1,11 @@
-Data for use in QuarkNet Data Camp
+# Data for use in QuarkNet Data Camp
+
+* 2011 Muon & Electron Runs - Use for Z, J / $\psi$, and $\Upsilon$ mass plots
+* 2011 Single Muon & Electron Runs - Use for W Boson mass plots
+
+>For 2015 Runs, the files are hosted on Google Drive. Use the following URLs to access the csv files:
+* Raw Electron Data       https://drive.google.com/uc?export=download&id=t17I_r75CK-19ixyG-czq9iphHwD3p4qsV&confirm=t
+* Raw Muon Data           https://drive.google.com/uc?export=download&id=1ykN2rQ2MsNt-F_Ky4lliaaWx5O_8oiPn&confirm=t 
+* Formatted Electron Data https://drive.google.com/uc?export=download&id=13onXkQVkzO2akLK5bAnvQdPfH4gY8-W_&confirm=t
+* Formatted Muon Data     https://drive.google.com/uc?export=download&id=1uIIfjiR4CGJ6W83tZF0glzQegzE7ZyXm&confirm=t
+


### PR DESCRIPTION
Added links to the large (1mil+) datasets for dilepton decays.
Updated CMS_event_analysis.ipynb to include options for messy double muon and messy double electron datasets.